### PR TITLE
feat: Auto-fill location update form

### DIFF
--- a/frontend/content/index.html
+++ b/frontend/content/index.html
@@ -41,7 +41,7 @@
         <select id="{{ .UpdateLocId }}" name="{{ .UpdateLocId }}" required>
             <option value="" disabled selected>-- Select a Location --</option>
             {{ range $loc := .Locations }}
-            <option value="{{ $loc.Id }}">{{ $loc.Title }}</option>
+            <option value="{{ $loc.Id }}" data-title="{{ $loc.Title }}" data-content="{{ $loc.Content }}">{{ $loc.Title }}</option>
             {{ end }}
         </select><br/><br/>
 
@@ -71,5 +71,20 @@
 
         <button type="submit">Update/Delete Location</button>
     </form>
+
+    <script>
+        const locationSelect = document.getElementById('{{ .UpdateLocId }}');
+        const newTitleInput = document.getElementById('{{ .UpdateLocTitle }}');
+        const newContentTextarea = document.getElementById('{{ .UpdateLocContent }}');
+
+        locationSelect.addEventListener('change', function() {
+            const selectedOption = this.options[this.selectedIndex];
+            const title = selectedOption.getAttribute('data-title');
+            const content = selectedOption.getAttribute('data-content');
+
+            newTitleInput.value = title;
+            newContentTextarea.value = content;
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
This change populates the 'New Title' and 'New Content' fields in the 'Update Location' form with the existing data of the selected location.

Modifications:
- Added `data-title` and `data-content` attributes to the `<option>` elements within the location selection dropdown in `frontend/content/index.html`. These attributes store the current title and content for each location.
- Added a JavaScript snippet to `frontend/content/index.html` that listens for the 'change' event on the location dropdown. When a location is selected, the script retrieves the `data-title` and `data-content` attributes from the selected option and uses them to populate the 'New Title' and 'New Content' form fields.